### PR TITLE
Fixed issues 11 through 14.

### DIFF
--- a/Sys/filenames.lisp
+++ b/Sys/filenames.lisp
@@ -238,6 +238,11 @@
 (defun pathname-type (pathname &key (case :local))
 	(declare (ignore case))
 	(pathnames::pathname-internal-type (pathname pathname)))
+
+(defun file-namestring (pathname)
+    (let ((name (pathname-name pathname))
+          (type (pathname-type pathname)))
+        (concatenate 'string name "." type)))
 	
 ;;;
 ;;;	Common Lisp LOAD-LOGICAL-PATHNAME-TRANSLATIONS function.

--- a/Sys/package.lisp
+++ b/Sys/package.lisp
@@ -583,7 +583,8 @@
 ;;;;
 (defun find-symbol (string &optional (package *package*))
 	(unless (packagep package)
-		(setq package (find-package package)))
+		(setq package (or (find-package package)
+                          (error "The name \"~A\" does not designate any package." package))))
 	(unless (packagep package)
 		(error "Invalid package: ~A" package))
     (with-synchronization (package-sync package)


### PR DESCRIPTION
Added a more informative error message when you :USE an
invalid package from DEFPACKAGE (#11).

Added an error check to FIND-SYMBOL so it can generate a non-cryptic
error message (#12)

Added a missing quote so that code that uses uninterned symbols in
the :IMPORT-FROM clause of DEFPACKAGE will work (#13)

Implemented FILE-NAMESTRING (#14).